### PR TITLE
fix(deploy): Exclude port from URL on Render.com

### DIFF
--- a/FileStream/config.py
+++ b/FileStream/config.py
@@ -34,7 +34,7 @@ class Server:
     NO_PORT = str(env.get("NO_PORT", "0").lower()) in ("1", "true", "t", "yes", "y")
     FQDN = str(env.get("FQDN", BIND_ADDRESS))
     URL = "http{}://{}{}/".format(
-        "s" if HAS_SSL else "", FQDN, "" if NO_PORT else ":" + str(PORT)
+        "s" if HAS_SSL else "", FQDN, "" if NO_PORT or ".onrender.com" in FQDN else ":" + str(PORT)
     )
 
 


### PR DESCRIPTION
The application was generating URLs that included the internal port number (e.g., `:8080`) when deployed on Render.com. This caused Render's Web Application Firewall (WAF) to block requests with a 403 Forbidden error.

This commit modifies the URL generation logic in `FileStream/config.py` to conditionally exclude the port from the URL if the `FQDN` indicates a Render.com deployment. This ensures that the generated download links are correctly formatted for the Render environment, resolving the WAF issue.